### PR TITLE
Restored minSdkVersion

### DIFF
--- a/ViewBinding-ktx/build.gradle
+++ b/ViewBinding-ktx/build.gradle
@@ -1,9 +1,11 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 30
+    defaultConfig {
+        minSdkVersion 15
+    }
     buildFeatures {
         viewBinding = true
     }


### PR DESCRIPTION
## Overview
- If targetSdkVersion < 4 any permission is granted.
<img width="513" alt="2020-11-05 17 16 53" src="https://user-images.githubusercontent.com/13705006/98215118-b8203b00-1f8a-11eb-8af9-d7851b71bc5f.png">

- So I want to fix it by removing permission or setting the minSdkVersion.