### PR TITLE
Replace jcenter() to mavenCentral()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.5.0'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
@@ -13,7 +13,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
- Warning "JCenter is at end of life" is displayed in Android Studio.
- Replace `jcenter()` with `mavenCentral()` as suggested
- Context
  -  https://developer.android.com/studio/build/jcenter-migration
- This PR same as a https://github.com/wada811/DataBinding-ktx/pull/15