### PR TITLE
Downgrade to require JDK1.8 or later

### DIFF
--- a/ViewBinding-ktx/build.gradle
+++ b/ViewBinding-ktx/build.gradle
@@ -18,11 +18,11 @@ android {
         viewBinding true
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
 


### PR DESCRIPTION
- Since 4.0.0, the JVM target is 17, so I want to downgrade.
- In my opinion, libraries should be able to be used across multiple versions without requiring the latest version.